### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you encounter exceptions such as `ClassNotFoundExceptions` ([#4](https://gith
 
 More details [visit official guide](http://developer.android.com/tools/help/proguard.html#configuring).
 
-#About me
+# About me
 
 A student in mainland China. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
