### PR TITLE
Fix bugs in BackEaseInOut#calculate

### DIFF
--- a/library/src/main/java/com/daimajia/easing/back/BackEaseInOut.java
+++ b/library/src/main/java/com/daimajia/easing/back/BackEaseInOut.java
@@ -41,7 +41,7 @@ public class BackEaseInOut extends BaseEasingMethod{
 
     @Override
     public Float calculate(float t, float b, float c, float d) {
-        if ((t /= d / 2) < 1) return c / 2 * (t * t * (((s *= (1.525)) + 1) * t - s)) + b;
-        return c / 2 * ((t -= 2) * t * (((s *= (1.525)) + 1) * t + s) + 2) + b;
+        if ((t /= d / 2) < 1) return c / 2 * (t * t * ((s + 1) * t - s)) + b;
+        return c / 2 * ((t -= 2) * t * ((s + 1) * t + s) + 2) + b;
     }
 }


### PR DESCRIPTION
Multiplying the 's' member of the class by 1.525 every time calculate was called was causing the method to be unusable.
Simply removing that multiplication gives the result I would expect, and makes the code resemble the BackEaseIn and BackEaseOut methods more closely.
