### PR TITLE
Change keyword "compile" to "implementation" for using library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ I found the [Easing Functions](http://easings.net/) made by [Robert Penne](http:
 Gradle
 
 ```groovy
-compile 'com.android.support:appcompat-v7:25.1.1'
-compile 'com.daimajia.easing:library:2.1@aar'
+implementation 'com.android.support:appcompat-v7:25.1.1'
+implementation 'com.daimajia.easing:library:2.1@aar'
 ```
 or maven
 
@@ -70,8 +70,7 @@ More details [visit official guide](http://developer.android.com/tools/help/prog
 
 # About me
 
-A student in mainland China. 
+A student in mainland China.
 
 Welcome to [offer me an internship](mailto:daimajia@gmail.com).
 If you have any new idea about this project, feel free to [contact me](mailto:daimajia@gmail.com).
-


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.

It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

I modified readme.md for this change