### PR TITLE
build: upgrade targetSdkVersion to 29 for migrating to AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,15 @@ I found the [Easing Functions](http://easings.net/) made by [Robert Penne](http:
 Gradle
 
 ```groovy
-implementation 'com.android.support:appcompat-v7:25.1.1'
-implementation 'com.daimajia.easing:library:2.1@aar'
+implementation 'com.daimajia.easing:library:2.2@aar'
 ```
 or maven
 
 ```xml
 <dependency>
-    <groupId>com.android.support</groupId>
-    <artifactId>appcompat-v7</artifactId>
-    <version>25.1.1</version>
-    <type>apklib</type>
-</dependency>
-<dependency>
     <groupId>com.daimajia.easing</groupId>
     <artifactId>library</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
     <type>apklib</type>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,17 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
+        google()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,19 +1,20 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 29
 
     defaultConfig {
-        applicationId "daimajia.com.eaing"
+        applicationId 'daimajia.com.eaing'
         minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 3
-        versionName "2.1"
+        targetSdkVersion 29
+        versionCode 6
+        versionName '2.2'
     }
+
     lintOptions {
         abortOnError false
     }
+
     buildTypes {
         release {
             minifyEnabled true
@@ -23,6 +24,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(":library")
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,10 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-
-
-VERSION_NAME=2.1
-VERSION_CODE=5
+VERSION_NAME=2.2
+VERSION_CODE=6
 GROUP=com.daimajia.easing
 
 POM_DESCRIPTION=Android Animation Easing Functions

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 13 23:03:05 CST 2017
+#Sat Aug 22 19:01:10 CST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 5
-        versionName "2.1"
+        targetSdkVersion 29
+        versionCode 6
+        versionName '2.2'
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
+
 apply from: './gradle-mvn-push.gradle'


### PR DESCRIPTION
According [this issue](https://github.com/daimajia/AndroidViewAnimations/issues/157) we want to migrate [daimajia/AndroidViewAnimations](https://github.com/daimajia/AndroidViewAnimations) to AndroidX.

Since [daimajia/AndroidViewAnimations](https://github.com/daimajia/AndroidViewAnimations) depends on this project, migrate this project to AndroidX first should be better.

Actually this project can support AndroidX without migration, but we should also keep this project up to date.

So we remove unused and outdated dependency **appcompat-v7**, and upgrade `targetSdkVersion` to 29.